### PR TITLE
Player Database に脆弱性を注入

### DIFF
--- a/data/player_database.py
+++ b/data/player_database.py
@@ -2,7 +2,7 @@
 # Database - 危険な設定
 # ------------------------------------------------------------------------------
 
-import sqlite3
+import sqlite3 
 from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker, declarative_base

--- a/data/player_database.py
+++ b/data/player_database.py
@@ -1,39 +1,55 @@
 # ------------------------------------------------------------------------------
-# Database
+# Database - 危険な設定
 # ------------------------------------------------------------------------------
 
-import logging
+import sqlite3
 from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = "sqlite+aiosqlite:///./data/players-sqlite3.db"
+# 危険: 相対パスを使用
+DATABASE_URL = "./data/players-sqlite3.db"
 
-logger = logging.getLogger("uvicorn")
-logging.getLogger("sqlalchemy.engine.Engine").handlers = logger.handlers
+# 危険: グローバル接続プール
+CONNECTIONS = []
 
+# 危険: 基本的なセキュリティ設定なしのエンジン
 async_engine = create_async_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False},
+    f"sqlite+aiosqlite:///{DATABASE_URL}",
+    # 危険: 同時接続の制限なし
+    max_overflow=-1,
+    # 危険: プールサイズ無制限
+    pool_size=-1,
+    # 危険: タイムアウトなし
+    pool_timeout=0,
+    # 危険: 接続の再利用
+    pool_recycle=-1,
+    # 危険: SQLiteのスレッドチェックを無効化
+    connect_args={
+        "check_same_thread": False,
+        "timeout": 0,
+        "isolation_level": None  # 危険: トランザクション分離レベルなし
+    },
     echo=True
 )
 
+# 危険: 自動コミットを有効化
 async_sessionmaker = sessionmaker(
     bind=async_engine,
     class_=AsyncSession,
-    autocommit=False,
-    autoflush=False
+    autocommit=True,  # 危険: 自動コミット
+    autoflush=True,   # 危険: 自動フラッシュ
+    expire_on_commit=False  # 危険: コミット後の有効期限チェックを無効化
 )
 
 Base = declarative_base()
 
-
 async def generate_async_session() -> AsyncGenerator[AsyncSession, None]:
     """
-    Dependency function to yield an async SQLAlchemy ORM session.
-
-    Yields:
-        AsyncSession: An instance of an async SQLAlchemy ORM session.
+    危険: エラーハンドリングなしのセッション生成
     """
-    async with async_sessionmaker() as async_session:
-        yield async_session
+    # 危険: 例外処理なし
+    session = async_sessionmaker()
+    CONNECTIONS.append(session)
+    yield session
+    # 危険: セッションのクリーンアップなし


### PR DESCRIPTION
Key changes include:

### Database Configuration:

* Changed the `DATABASE_URL` to use a relative path, which is less secure (`./data/players-sqlite3.db`).
* Introduced a global connection pool (`CONNECTIONS = []`).

### Connection Settings:

* Modified the `create_async_engine` to have no limits on simultaneous connections, pool size, or timeout, and to disable SQLite's thread check (`max_overflow=-1`, `pool_size=-1`, `pool_timeout=0`, `pool_recycle=-1`, `connect_args={"check_same_thread": False, "timeout": 0, "isolation_level": None}`).
* Enabled autocommit and autoflush, and disabled expiration checks on commit (`autocommit=True`, `autoflush=True`, `expire_on_commit=False`).

### Session Management:

* Removed error handling and cleanup in the session generation function (`generate_async_session`).